### PR TITLE
Use sets rather than the global redis key namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :test do
   unless ENV['TRAVIS']
-    gem 'byebug', '~> 10', platform: :mri, require: false
-    gem 'pry', '~> 0', platform: :mri, require: false
-    gem 'pry-byebug', '~> 3', platform: :mri, require: false
+    gem 'byebug', '~> 11.3'
+    gem 'pry', '~> 0.13.2'
+    gem 'minitest-focus', '~> 1.2.1'
   end
   gem 'rubocop', '~> 0.60.0'
   gem 'simplecov', '~> 0', require: false

--- a/lib/resque/plugins/unique_in_queue.rb
+++ b/lib/resque/plugins/unique_in_queue.rb
@@ -19,7 +19,11 @@ module Resque
 
       module ClassMethods
         def unique_in_queue_redis_key(queue, item)
-          "#{unique_in_queue_key_base}:queue:#{queue}:job:#{Resque::UniqueInQueue::Queue.const_for(item).redis_key(item)}"
+          "#{unique_in_queue_key_base}:queue:#{queue}:job"
+        end
+
+        def unique_in_queue_redis_value(queue, item)
+          Resque::UniqueInQueue::Queue.const_for(item).redis_key(item)
         end
 
         # Payload is what Resque stored for this job along with the job's class name:

--- a/lib/resque/unique_in_queue/queue.rb
+++ b/lib/resque/unique_in_queue/queue.rb
@@ -64,8 +64,9 @@ module Resque
       end
 
       def cleanup(queue)
-        keys = redis.keys("#{Resque::UniqueInQueue.configuration&.unique_in_queue_key_base}:queue:#{queue}:job:*")
-        redis.del(*keys) if keys.any?
+        pattern = "#{Resque::UniqueInQueue.configuration&.unique_in_queue_key_base}:queue:#{queue}:job:*"
+        keys = redis.scan_each(match: pattern, count: 1_000_000).to_a
+        redis.del(keys) if keys.any?
       end
 
       private

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -45,12 +45,11 @@ class JobTest < MiniTest::Spec
     assert_equal 1, Resque.size(:unique)
   end
 
-  focus
   it 'mark jobs as unqueued when Resque processes them' do
     Resque.enqueue FakeUniqueInQueue, 'foo'
     assert Resque.enqueued?(FakeUniqueInQueue, 'foo')
     Resque.reserve(:unique)
-    assert !Resque.enqueued?(FakeUniqueInQueue, 'foo')
+    refute Resque.enqueued?(FakeUniqueInQueue, 'foo')
   end
 
   it 'mark jobs as unqueued when they raise an exception' do

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -81,6 +81,9 @@ class JobTest < MiniTest::Spec
     Resque.enqueue FakeUniqueInQueue, 'foo'
     Resque.enqueue FailingUniqueInQueue, 'foo'
     Resque.remove_queue(:unique)
+    refute Resque.enqueued?(FakeUniqueInQueue, 'foo')
+    refute Resque.enqueued?(FailingUniqueInQueue, 'foo')
+
     Resque.enqueue(FakeUniqueInQueue, 'foo')
     assert_equal 1, Resque.size(:unique)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,9 @@ require 'fake_jobs'
 require 'fakeredis/minitest'
 
 begin
-  require 'pry-byebug'
+  require 'minitest/focus'
+  # require 'pry'
+  require 'byebug'
 rescue LoadError
-  # ignore
 end
+


### PR DESCRIPTION
Cleaning up the queue using bare string keys is way too slow. We can speed this up by using SETs.