### PR TITLE
build(deps): remove colorize dependency

### DIFF
--- a/lib/resque-unique_in_queue.rb
+++ b/lib/resque-unique_in_queue.rb
@@ -6,7 +6,6 @@ require 'resque/unique_in_queue/version'
 require 'digest/md5'
 
 # External Gems
-require 'colorized_string'
 require 'resque'
 
 # This Gem
@@ -23,7 +22,13 @@ require 'resque/unique_in_queue/configuration'
 #   Resque, Resque::Job, or Resque::Queue.
 module Resque
   module UniqueInQueue
-    PLUGIN_TAG = (ColorizedString['[R-UIQ] '].blue).freeze
+    # Wraps text in ANSI blue escape codes. Replaces the former `colorize`
+    # dependency; produces the exact sequence colorize's String#blue emitted.
+    def self.blue_text(text)
+      "\e[0;34;49m#{text}\e[0m"
+    end
+
+    PLUGIN_TAG = blue_text('[R-UIQ] ').freeze
 
     def log(message)
       configuration.logger&.send(configuration.log_level, message) if configuration.logger

--- a/lib/resque/unique_in_queue/version.rb
+++ b/lib/resque/unique_in_queue/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module UniqueInQueue
-    VERSION = '2.0.1'.freeze
+    VERSION = '2.0.2'.freeze
   end
 end

--- a/resque-unique_in_queue.gemspec
+++ b/resque-unique_in_queue.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'colorize', '>= 0.8'
   spec.add_runtime_dependency 'resque', '>= 1.2'
 
   spec.add_development_dependency 'bundler', '>= 2.2.10'


### PR DESCRIPTION
## What
Removes the `colorize` runtime dependency. Its only use was rendering the blue `[R-UIQ] ` debug-log prefix, which is now produced by a small inline ANSI helper (`blue_text`) that emits the exact same escape sequence. Output is unchanged.

## Why
`colorize` is licensed under **GPL-2.0** (a strong copyleft license). This gem is MIT-licensed and is embedded as a runtime dependency in other projects, so pulling in a GPL-2.0 dependency creates a license-compatibility risk for downstream consumers. Since the dependency was used for a single decorative log prefix, it's cleaner to drop it entirely than to carry that risk.

## Changes
- Remove `colorize` from the gemspec and the `require`
- Add `Resque::UniqueInQueue.blue_text` and build `PLUGIN_TAG` from it
- Bump version 2.0.1 → 2.0.2

No public API or behavior changes; debug output is byte-identical.